### PR TITLE
add quotes to http_doc variable

### DIFF
--- a/bin/apache
+++ b/bin/apache
@@ -126,7 +126,7 @@ log "open browser at http://127.0.0.1:${http_prt}/"
 ${APACHE} \
     -f ${HTTP_CNF} \
     -k start  \
-    -C "DocumentRoot ${http_doc}" \
+    -C "DocumentRoot '${http_doc}'" \
     -C "ErrorLog     ${http_log}" \
     -C "LogFormat    '%h %l %u %t \"%r\" %>s %b' common" \
     -C "CustomLog    ${http_acc}" \


### PR DESCRIPTION
Paths with spaces will be parsed as two arguments to DocumentRoot causing the script to fail. Additional quotes prevent that.