### PR TITLE
Update apache to use bash chosen by user

### DIFF
--- a/bin/apache
+++ b/bin/apache
@@ -126,7 +126,7 @@ log "open browser at http://127.0.0.1:${http_prt}/"
 ${APACHE} \
     -f ${HTTP_CNF} \
     -k start  \
-    -C "DocumentRoot ${http_doc}" \
+    -C "DocumentRoot '${http_doc}'" \
     -C "ErrorLog     ${http_log}" \
     -C "LogFormat    '%h %l %u %t \"%r\" %>s %b' common" \
     -C "CustomLog    ${http_acc}" \

--- a/bin/apache
+++ b/bin/apache
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 APACHE=/usr/sbin/httpd
 HTTP_PORT_DEFAULT=8686


### PR DESCRIPTION
Many users opt to use a custom bash with a heavily customized environment. That may or may not affect this script, but using #!/usr/bin/env bash accommodates those scenarios and makes the script more portable.
