### PR TITLE
Patch for current Homebrew Apache running on High Sierra

### DIFF
--- a/bin/apache
+++ b/bin/apache
@@ -126,7 +126,7 @@ log "open browser at http://127.0.0.1:${http_prt}/"
 ${APACHE} \
     -f ${HTTP_CNF} \
     -k start  \
-    -C "DocumentRoot ${http_doc}" \
+    -C "DocumentRoot '${http_doc}'" \
     -C "ErrorLog     ${http_log}" \
     -C "LogFormat    '%h %l %u %t \"%r\" %>s %b' common" \
     -C "CustomLog    ${http_acc}" \

--- a/bin/apache
+++ b/bin/apache
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-APACHE=/usr/sbin/httpd
 HTTP_PORT_DEFAULT=8686
+if [ -f $(brew --prefix)/bin/httpd ]; then
+  APACHE=$(brew --prefix)/bin/httpd
+  MODULES=BrewModules
+else
+  APACHE=/usr/sbin/httpd
+  MODULES=SystemModules
+fi
 
 ROOT="`cd $(dirname $0) && pwd`/.."
 HTTP_CNF=${ROOT}/config/httpd.conf
@@ -16,22 +22,22 @@ usage() {
     echo
 }
 
-kill() { 
+kill() {
     port=$1
     log "stopping processes running on port ${port}"
     lsof -i tcp:${port} | awk 'NR!=1 {print $2}' | xargs kill
     exit
 }
 
-log() { 
+log() {
     echo -e "${apache} ${1}"
 }
 
-error() { 
+error() {
     echo -e "${apache} $(tput bold)$(tput setaf 1)error - ${1}$(tput sgr0)"
 }
 
-clean() { 
+clean() {
     typeset directory
     directory="/tmp/apache-anywhere/${1}"
     if [ -d ${directory} ]
@@ -44,7 +50,7 @@ clean() {
     exit
 }
 
-check_port() { 
+check_port() {
     typeset return_code
     eval lsof -i tcp:${1}
     return_code=$?
@@ -56,7 +62,7 @@ check_port() {
     fi
 }
 
-function setup_log { 
+function setup_log {
     mkdir -p ${TEMP_LOG}
     http_log=${TEMP_LOG}/apache.log
     http_acc="${TEMP_LOG}/access.log common"
@@ -64,11 +70,11 @@ function setup_log {
     http_lck=${TEMP_LOG}
 }
 
-exists() { 
+exists() {
     hash "$1" &> /dev/null ;
 }
 
-getargs() { 
+getargs() {
 
     while getopts ":d:p:" o; do
         case "${o}" in
@@ -132,7 +138,8 @@ ${APACHE} \
     -C "CustomLog    ${http_acc}" \
     -C "PidFile      ${http_pid}" \
     -C "Mutex        file:${http_lck} default" \
-    -C "Listen       ${http_prt}"
+    -C "Listen       ${http_prt}" \
+    -D${MODULES}
 
 if [ $? != 0 ]
 then

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -4,7 +4,7 @@
 ServerName localhost
 
 <IfDefine SystemModules>
-  LoadModule php7_module          /usr/libexec/apache2/libphp7.so
+  #LoadModule php7_module          /usr/libexec/apache2/libphp7.so
   LoadModule access_compat_module /usr/libexec/apache2/mod_access_compat.so
   LoadModule authn_core_module    /usr/libexec/apache2/mod_authn_core.so
   LoadModule authz_core_module    /usr/libexec/apache2/mod_authz_core.so
@@ -20,7 +20,7 @@ ServerName localhost
 </IfDefine>
 
 <IfDefine BrewModules>
-  LoadModule php7_module          /usr/libexec/apache2/libphp7.so
+  #LoadModule php7_module          /usr/libexec/apache2/libphp7.so
   LoadModule access_compat_module /usr/local/lib/httpd/modules/mod_access_compat.so
   LoadModule authn_core_module    /usr/local/lib/httpd/modules/mod_authn_core.so
   LoadModule authz_core_module    /usr/local/lib/httpd/modules/mod_authz_core.so

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -3,18 +3,38 @@
 
 ServerName localhost
 
-LoadModule dir_module           libexec/apache2/mod_dir.so
-LoadModule mime_module          libexec/apache2/mod_mime.so
-LoadModule log_config_module    libexec/apache2/mod_log_config.so
-LoadModule authz_host_module    libexec/apache2/mod_authz_host.so
-LoadModule autoindex_module     libexec/apache2/mod_autoindex.so
-LoadModule headers_module       libexec/apache2/mod_headers.so
-LoadModule rewrite_module       libexec/apache2/mod_rewrite.so
-LoadModule cgi_module           libexec/apache2/mod_cgi.so
-LoadModule access_compat_module libexec/apache2/mod_access_compat.so
-LoadModule unixd_module         libexec/apache2/mod_unixd.so
-LoadModule authn_core_module    libexec/apache2/mod_authn_core.so
-LoadModule authz_core_module    libexec/apache2/mod_authz_core.so
+<IfDefine SystemModules>
+  LoadModule php7_module          /usr/libexec/apache2/libphp7.so
+  LoadModule access_compat_module /usr/libexec/apache2/mod_access_compat.so
+  LoadModule authn_core_module    /usr/libexec/apache2/mod_authn_core.so
+  LoadModule authz_core_module    /usr/libexec/apache2/mod_authz_core.so
+  LoadModule authz_host_module    /usr/libexec/apache2/mod_authz_host.so
+  LoadModule autoindex_module     /usr/libexec/apache2/mod_autoindex.so
+  LoadModule cgi_module           /usr/libexec/apache2/mod_cgi.so
+  LoadModule dir_module           /usr/libexec/apache2/mod_dir.so
+  LoadModule headers_module       /usr/libexec/apache2/mod_headers.so
+  LoadModule log_config_module    /usr/libexec/apache2/mod_log_config.so
+  LoadModule mime_module          /usr/libexec/apache2/mod_mime.so
+  LoadModule rewrite_module       /usr/libexec/apache2/mod_rewrite.so
+  LoadModule unixd_module         /usr/libexec/apache2/mod_unixd.so
+</IfDefine>
+
+<IfDefine BrewModules>
+  LoadModule php7_module          /usr/libexec/apache2/libphp7.so
+  LoadModule access_compat_module /usr/local/lib/httpd/modules/mod_access_compat.so
+  LoadModule authn_core_module    /usr/local/lib/httpd/modules/mod_authn_core.so
+  LoadModule authz_core_module    /usr/local/lib/httpd/modules/mod_authz_core.so
+  LoadModule authz_host_module    /usr/local/lib/httpd/modules/mod_authz_host.so
+  LoadModule autoindex_module     /usr/local/lib/httpd/modules/mod_autoindex.so
+  LoadModule cgi_module           /usr/local/lib/httpd/modules/mod_cgi.so
+  LoadModule dir_module           /usr/local/lib/httpd/modules/mod_dir.so
+  LoadModule headers_module       /usr/local/lib/httpd/modules/mod_headers.so
+  LoadModule log_config_module    /usr/local/lib/httpd/modules/mod_log_config.so
+  LoadModule mime_module          /usr/local/lib/httpd/modules/mod_mime.so
+  LoadModule mpm_prefork_module   /usr/local/lib/httpd/modules/mod_mpm_prefork.so
+  LoadModule rewrite_module       /usr/local/lib/httpd/modules/mod_rewrite.so
+  LoadModule unixd_module         /usr/local/lib/httpd/modules/mod_unixd.so
+</IfDefine>
 
 AddHandler cgi-script .cgi .rb .pl
 


### PR DESCRIPTION
I recently upgraded to High Sierra and then used apache-anywhere for the first time in a long long time. __It didn't work.__ I had Homebrew installed and was using its version of `httpd`. For some reason, it now requires an MPM module to be explicitly loaded, while the macOS system's `httpd` works just fine without it.

In the end, the researching and testing to solve the issue led me to modify the apache-anywhere script to work with both, Homebrew and macOS Apaches, without any modification other than unlink brew's binaries using `brew unlink httpd`. 

In other words, Apache from Homebrew takes precedence, but if it's not installed or not linked, the default Apache will run instead.

PHP modules were also added as comments, so users don't have to hunt them down in order to use it. 

I'm requesting this pull because I think other Homebrew users may find it useful. And will still run fine if used with Linux or in a Mac sans Homebrew. 